### PR TITLE
Feat: Diary에 BaseEntity 상속, Flower 꽃다발 필드 추가

### DIFF
--- a/src/main/java/flory/FloryServer/domain/Diary.java
+++ b/src/main/java/flory/FloryServer/domain/Diary.java
@@ -1,5 +1,6 @@
 package flory.FloryServer.domain;
 
+import flory.FloryServer.domain.base.BaseEntity;
 import flory.FloryServer.domain.enums.FlowerMeaning;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 
-public class Diary {
+public class Diary extends BaseEntity {
 
     @Id
     // 기본 키 생성

--- a/src/main/java/flory/FloryServer/domain/Flower.java
+++ b/src/main/java/flory/FloryServer/domain/Flower.java
@@ -32,6 +32,10 @@ public class Flower extends BaseEntity {
     @Setter
     private String flower_url;
 
+    @Getter
+    @Setter
+    private String bouquet_url;
+
     @OneToMany(mappedBy = "flower", cascade = CascadeType.ALL)
     private List<Diary> DiaryList = new ArrayList<>();
 


### PR DESCRIPTION
- Diary 엔티티에 생성일자(createdAt)와 수정일자(updatedAt)를 자동으로 관리하기 위해 BaseTime 추상 클래스를 상속.
- Flower 엔티티에 BouquetUrl 필드를 추가하여 꽃다발 이미지 URL을 저장할 수 있도록 개선.