### PR TITLE
Rename: Gift 필드 변수명 정리

### DIFF
--- a/src/main/java/flory/FloryServer/domain/Gift.java
+++ b/src/main/java/flory/FloryServer/domain/Gift.java
@@ -19,9 +19,9 @@ public class Gift extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String message;
 
-    // <외래키> userId, userNickname, receiverId, flowerId(부케), cardId
+    // <외래키> userId, targetId, flowerId, cardId
     @ManyToOne(fetch = FetchType.LAZY)  // N:1에서 N에 해당하는 엔티티가 1에 해당하는 엔티티와 매핑
-    @JoinColumn(name = "sender_id")     // 실제 데이터베이스에서 해당하는 칼럼명
+    @JoinColumn(name = "user_id")     // 실제 데이터베이스에서 해당하는 칼럼명
     private User user;
 
     /*@ManyToOne(fetch = FetchType.LAZY)
@@ -29,11 +29,11 @@ public class Gift extends BaseEntity {
     private User user; // ?같은 인스턴스 다른 칼럼*/
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "receiver_id")
-    private User receiver;
+    @JoinColumn(name = "target_id")
+    private User target;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bouquet_id")
+    @JoinColumn(name = "flower_id")
     // private Flower bouquet;
     private Flower flower;
 


### PR DESCRIPTION
- 코드의 가독성과 의미 전달을 명확하게 하기 위해 변수명을 변경했습니다.
- receiver를 target으로, sender를 user로 변경하여 의미 명확화
- bouquet를 flower로 변경하여 일관성 유지